### PR TITLE
Add opinionated formatter

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,36 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: [
+    '@typescript-eslint',
+    'jest'
+  ],
+  extends: [
+    'standard',
+    'standard-react',
+    'plugin:jest/recommended',
+    'plugin:jest/style'
+  ],
+  rules: {
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ['error', {
+      vars: 'all',
+      args: 'after-used',
+      ignoreRestSiblings: false
+    }],
+    'array-bracket-newline': ['error', { 'multiline': true }],
+    'max-len': ['error', {
+      code: 100,
+      tabWidth: 2
+    }],
+    'jsx-quotes': ['error', 'prefer-double'],
+    'react/jsx-max-props-per-line': ['error', {
+      maximum: 1,
+      when: 'multiline'
+    }],
+    'sort-imports': ['error', { memberSyntaxSortOrder: ['single', 'all', 'multiple', 'none'] }],
+    'prefer-template': 'error',
+    'arrow-body-style': ['error', 'as-needed'],
+    'object-curly-newline': ["error", { "multiline": true }]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+
+# IDE
+.vscode

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 In the project directory, you can run:
 
+### `yarn lint`
+
+Runs the linter inside folder `src`. Run with `--fix` in order to apply all automatic fixes.
+```
+$ yarn lint --fix
+```
+
 ### `yarn start`
 
 Runs the app in the development mode.<br />

--- a/package.json
+++ b/package.json
@@ -20,9 +20,21 @@
     "@types/react": "16.9.13",
     "@types/react-dom": "16.9.4",
     "@types/react-router": "^5.1.3",
-    "@types/react-router-dom": "^5.1.3"
+    "@types/react-router-dom": "^5.1.3",
+    "@typescript-eslint/eslint-plugin": "^2.15.0",
+    "@typescript-eslint/parser": "^2.15.0",
+    "eslint": "^6.8.0",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-config-standard-react": "^9.2.0",
+    "eslint-plugin-import": "^2.19.1",
+    "eslint-plugin-jest": "^23.3.0",
+    "eslint-plugin-node": "^11.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-react": "^7.17.0",
+    "eslint-plugin-standard": "^4.0.1"
   },
   "scripts": {
+    "lint": "eslint src --ext .ts,.tsx",
     "start": "PORT=3002 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
+import App from './App'
+import React from 'react'
+import ReactDOM from 'react-dom'
 
 it('renders without crashing', () => {
-  const div = document.createElement('div');
-  ReactDOM.render(<App />, div);
-  ReactDOM.unmountComponentAtNode(div);
-});
+  const div = document.createElement('div')
+  ReactDOM.render(<App />, div)
+  ReactDOM.unmountComponentAtNode(div)
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,40 +1,36 @@
+import { Brand } from '@patternfly/react-core'
+import React from 'react'
+import logo from './assets/logo.svg'
+import { AppLayout, LazyRoute, SwitchWith404 } from './components'
+import { Redirect, useHistory } from 'react-router-dom'
 import 'react-app-polyfill/ie11'
 import '@patternfly/react-core/dist/styles/base.css'
-import {Brand} from '@patternfly/react-core'
-import React from 'react'
-import {Redirect, useHistory} from 'react-router-dom'
-import {AppLayout, SwitchWith404, LazyRoute} from './components'
 import './App.css'
-import logo from './assets/logo.svg'
 
-const Logo = <Brand src={logo} alt={'patternfly logo'}/>
+const Logo = <Brand src={logo} alt="patternfly logo" />
 const navItems = [
   {
     title: 'Overview',
     to: '/',
-    exact: true,
+    exact: true
   },
   {
     title: 'Analytics',
     to: '/analytics',
-    items: [
-      {to: '/analytics/usage', title: 'Usage'},
-    ],
+    items: [{ to: '/analytics/usage', title: 'Usage' }]
   },
   {
     title: 'Applications',
     to: '/applications',
     items: [
-      {to: '/applications', title: 'Listing'},
-      {to: '/applications/plans', title: 'Application Plans'}
-    ],
+      { to: '/applications', title: 'Listing' },
+      { to: '/applications/plans', title: 'Application Plans' }
+    ]
   },
   {
     title: 'Integration',
     to: '/integration',
-    items: [
-      {to: '/integration/configuration', title: 'Configuration'}
-    ]
+    items: [{ to: '/integration/configuration', title: 'Configuration' }]
   }
 ]
 
@@ -44,27 +40,21 @@ const getApplicationsPage = () => import('./pages/Applications')
 const App = () => {
   const history = useHistory()
   const logoProps = React.useMemo(
-    () => ({
-      onClick: () => history.push('/'),
-    }),
+    () => ({ onClick: () => history.push('/') }),
     [history]
   )
   return (
     <AppLayout
       logo={Logo}
       logoProps={logoProps}
-      navVariant={'vertical'}
+      navVariant="vertical"
       navItems={navItems}
-      navGroupsStyle={'expandable'}
+      navGroupsStyle="expandable"
     >
       <SwitchWith404>
-        <LazyRoute path="/" exact={true} getComponent={getOverviewPage} />
-        <LazyRoute path="/applications" exact={true} getComponent={getApplicationsPage} />
-        <Redirect
-          path={'/overview'}
-          to={'/'}
-          exact={true}
-        />
+        <LazyRoute path="/" exact getComponent={getOverviewPage} />
+        <LazyRoute path="/applications" exact getComponent={getApplicationsPage} />
+        <Redirect path="/overview" to="/" exact />
       </SwitchWith404>
     </AppLayout>
   )

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,25 +1,23 @@
-import * as React from 'react'
+import React from 'react'
+import { AppNavExpandable, IAppNavExpandableProps } from './AppNavExpandable'
+import { AppNavGroup, IAppNavGroupProps } from './AppNavGroup'
+import { AppNavItem, IAppNavItemProps } from './AppNavItem'
 import {
   Nav,
   NavList,
   NavVariants,
   Page,
   PageHeader,
-  PageSidebar,
-  SkipToContent,
   PageHeaderProps,
+  PageSidebar,
+  SkipToContent
 } from '@patternfly/react-core'
-import {AppNavExpandable, IAppNavExpandableProps} from './AppNavExpandable'
-import {AppNavGroup, IAppNavGroupProps} from './AppNavGroup'
-import {AppNavItem, IAppNavItemProps} from './AppNavItem'
 
 export interface IAppLayoutContext {
   setBreadcrumb: (breadcrumb: React.ReactNode) => void
 }
 
-export const AppLayoutContext = React.createContext<IAppLayoutContext>({
-  setBreadcrumb: () => void 0,
-})
+export const AppLayoutContext = React.createContext<IAppLayoutContext>({ setBreadcrumb: () => 0 })
 
 export interface IAppLayoutProps
   extends Pick<PageHeaderProps, 'logo'>,
@@ -45,7 +43,7 @@ export const AppLayout: React.FunctionComponent<IAppLayoutProps> = ({
   startWithOpenNav = true,
   theme = 'dark',
   mainContainerId = 'main-container',
-  children,
+  children
 }) => {
   const [isNavOpen, setIsNavOpen] = React.useState(startWithOpenNav)
   const [isMobileView, setIsMobileView] = React.useState(true)
@@ -88,18 +86,18 @@ export const AppLayout: React.FunctionComponent<IAppLayoutProps> = ({
         <Nav id="nav-primary-simple" theme={theme}>
           <NavList id="nav-list-simple" variant={variant}>
             {navItems.map((navItem, idx) => {
-              if (navItem && navItem.hasOwnProperty('items') && isVertical) {
+              if (navItem && ('items' in navItem) && isVertical) {
                 return navGroupsStyle === 'expandable' ? (
                   <AppNavExpandable
                     {...(navItem as IAppNavExpandableProps)}
                     key={idx}
                   />
                 ) : (
-                  <AppNavGroup {...(navItem as IAppNavGroupProps)} key={idx}/>
+                  <AppNavGroup {...(navItem as IAppNavGroupProps)} key={idx} />
                 )
               } else {
                 return (
-                  <AppNavItem {...(navItem as IAppNavItemProps)} key={idx}/>
+                  <AppNavItem {...(navItem as IAppNavItemProps)} key={idx} />
                 )
               }
             })}
@@ -132,7 +130,7 @@ export const AppLayout: React.FunctionComponent<IAppLayoutProps> = ({
       isMobileView,
       onNavToggle,
       onNavToggleMobile,
-      Navigation,
+      Navigation
     ]
   )
 
@@ -154,9 +152,9 @@ export const AppLayout: React.FunctionComponent<IAppLayoutProps> = ({
     <SkipToContent href="#primary-app-container">
       Skip to Content
     </SkipToContent>
-  );
+  )
   return (
-    <AppLayoutContext.Provider value={{setBreadcrumb: handleSetBreadcrumb}}>
+    <AppLayoutContext.Provider value={{ setBreadcrumb: handleSetBreadcrumb }}>
       <Page
         mainContainerId={mainContainerId}
         header={Header}

--- a/src/components/AppNavExpandable.tsx
+++ b/src/components/AppNavExpandable.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react'
-import {useRouteMatch} from 'react-router-dom'
-import {NavExpandable} from '@patternfly/react-core'
-import {AppNavItem, IAppNavItemProps} from './AppNavItem'
+import { NavExpandable } from '@patternfly/react-core'
+import React from 'react'
+import { useRouteMatch } from 'react-router-dom'
+import { AppNavItem, IAppNavItemProps } from './AppNavItem'
 
 export interface IAppNavExpandableProps {
   title: string;
@@ -9,15 +9,17 @@ export interface IAppNavExpandableProps {
   items: Array<IAppNavItemProps | undefined>;
 }
 
-export const AppNavExpandable: React.FunctionComponent<IAppNavExpandableProps> = ({title, to, items}) => {
-  const match = useRouteMatch({
-    path: to,
-  })
+export const AppNavExpandable: React.FunctionComponent<IAppNavExpandableProps> = ({
+  title,
+  to,
+  items
+}: IAppNavExpandableProps) => {
+  const match = useRouteMatch({ path: to })
   const isActive = !!match
   return (
     <NavExpandable title={title} isActive={isActive} isExpanded={isActive}>
       {items.map((subNavItem, jdx) => (
-        <AppNavItem {...subNavItem} key={jdx}/>
+        <AppNavItem {...subNavItem} key={jdx} />
       ))}
     </NavExpandable>
   )

--- a/src/components/AppNavGroup.tsx
+++ b/src/components/AppNavGroup.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react'
-import {NavGroup} from '@patternfly/react-core'
-import {AppNavItem, IAppNavItemProps} from './AppNavItem'
+import { NavGroup } from '@patternfly/react-core'
+import React from 'react'
+import { AppNavItem, IAppNavItemProps } from './AppNavItem'
 
 export interface IAppNavGroupProps {
   title: string;
@@ -9,13 +9,11 @@ export interface IAppNavGroupProps {
 
 export const AppNavGroup: React.FunctionComponent<IAppNavGroupProps> = ({
   title,
-  items,
-}) => {
-  return (
-    <NavGroup title={title}>
-      {items.map((subNavItem, jdx) => (
-        <AppNavItem {...subNavItem} key={jdx}/>
-      ))}
-    </NavGroup>
-  )
-}
+  items = []
+}: IAppNavGroupProps) => (
+  <NavGroup title={title}>
+    {items.map((subNavItem, jdx) => (
+      <AppNavItem {...subNavItem} key={jdx} />
+    ))}
+  </NavGroup>
+)

--- a/src/components/AppNavItem.tsx
+++ b/src/components/AppNavItem.tsx
@@ -1,7 +1,7 @@
+import { NavLink } from 'react-router-dom'
+import React from 'react'
 import * as H from 'history'
-import * as React from 'react'
-import {NavLink} from 'react-router-dom'
-import {NavItem, NavItemSeparator} from '@patternfly/react-core'
+import { NavItem, NavItemSeparator } from '@patternfly/react-core'
 
 export interface IAppNavItemProps<S = {}> {
   title?: string
@@ -11,9 +11,9 @@ export interface IAppNavItemProps<S = {}> {
   exact?: boolean
 }
 
-export function AppNavItem<S>({title, to, exact}: IAppNavItemProps<S>) {
+export function AppNavItem<S> ({ title, to, exact }: IAppNavItemProps<S>) {
   if (!title || !to) {
-    return <NavItemSeparator data-testid={'navitem-separator'}/>
+    return <NavItemSeparator data-testid="navitem-separator" />
   }
   return (
     <NavItem>

--- a/src/components/LazyRoute.tsx
+++ b/src/components/LazyRoute.tsx
@@ -1,19 +1,17 @@
-import * as React from 'react'
-import {RouteProps, Route} from 'react-router-dom'
-import {Loading} from './Loading'
+import { Loading } from './Loading'
+import React from 'react'
+import { Route, RouteProps } from 'react-router-dom'
 
 export interface IDynamicImportProps extends RouteProps {
   getComponent: () => Promise<{ default: React.ComponentType }>;
 }
 
-export function LazyRoute({getComponent, ...props}: IDynamicImportProps) {
-  const LazyComponent = React.useMemo(() => React.lazy(getComponent), [
-    getComponent,
-  ])
+export function LazyRoute ({ getComponent, ...props }: IDynamicImportProps) {
+  const LazyComponent = React.useMemo(() => React.lazy(getComponent), [getComponent])
   return (
     <Route {...props}>
-      <React.Suspense fallback={<Loading/>}>
-        <LazyComponent/>
+      <React.Suspense fallback={<Loading />}>
+        <LazyComponent />
       </React.Suspense>
     </Route>
   )

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,17 +1,17 @@
-import * as React from 'react'
+import React from 'react'
+import { Spinner } from '@patternfly/react-core/dist/js/experimental'
 import {
   EmptyState,
   EmptyStateIcon,
   EmptyStateVariant,
   PageSection,
-  Title,
+  Title
 } from '@patternfly/react-core'
-import {Spinner} from '@patternfly/react-core/dist/js/experimental'
 
 export const Loading: React.FunctionComponent = () => (
   <PageSection aria-label="Loading Content Container">
     <EmptyState variant={EmptyStateVariant.full}>
-      <EmptyStateIcon variant="container" component={Spinner}/>
+      <EmptyStateIcon variant="container" component={Spinner} />
       <Title size="lg">Loading</Title>
     </EmptyState>
   </PageSection>

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,16 +1,16 @@
-import * as React from 'react'
-import {NavLink} from 'react-router-dom'
-import {Alert, PageSection} from '@patternfly/react-core'
-import {useA11yRouteChange} from './util/useA11yRoute'
-import {useDocumentTitle} from './util/useDocumentTitle'
+import { NavLink } from 'react-router-dom'
+import React from 'react'
+import { useA11yRouteChange } from './util/useA11yRoute'
+import { useDocumentTitle } from './util/useDocumentTitle'
+import { Alert, PageSection } from '@patternfly/react-core'
 
 export const NotFound: React.FunctionComponent = () => {
   useA11yRouteChange()
   useDocumentTitle('Page not found')
   return (
     <PageSection>
-      <Alert variant="danger" title="404! This view hasn't been created yet."/>
-      <br/>
+      <Alert variant="danger" title="404! This view hasn't been created yet." />
+      <br />
       <NavLink to="/" className="pf-c-nav__link">
         Take me home
       </NavLink>

--- a/src/components/SwitchWith404.tsx
+++ b/src/components/SwitchWith404.tsx
@@ -1,14 +1,14 @@
-import * as React from 'react'
-import {SwitchProps, Switch, Route, useRouteMatch} from 'react-router-dom'
-import {NotFound} from './NotFound'
+import { NotFound } from './NotFound'
+import React from 'react'
+import { Route, Switch, SwitchProps, useRouteMatch } from 'react-router-dom'
 
 export const SwitchWith404: React.FunctionComponent<SwitchProps> = ({
-                                                                      children,
-                                                                      ...props
-                                                                    }) => {
+  children,
+  ...props
+}: SwitchProps) => {
   const match = useRouteMatch()
   const defaultMatch = React.useMemo(
-    () => match && <Route path={match.path} exact={true}/>,
+    () => match && <Route path={match.path} exact />,
     [match]
   )
   return (
@@ -20,7 +20,7 @@ export const SwitchWith404: React.FunctionComponent<SwitchProps> = ({
        */}
       {defaultMatch}
       <Route>
-        <NotFound/>
+        <NotFound />
       </Route>
     </Switch>
   )

--- a/src/components/util/useA11yRoute.ts
+++ b/src/components/util/useA11yRoute.ts
@@ -1,7 +1,7 @@
-import * as React from 'react'
-import {LastLocationType, useLastLocation} from 'react-router-last-location'
+import React from 'react'
+import { LastLocationType, useLastLocation } from 'react-router-last-location'
 
-export function accessibleRouteChangeHandler(id: string, timeout = 50) {
+export function accessibleRouteChangeHandler (id: string, timeout = 50) {
   return window.setTimeout(() => {
     const mainContainer = document.getElementById(id)
     if (mainContainer) {

--- a/src/components/util/useBreadcrumb.ts
+++ b/src/components/util/useBreadcrumb.ts
@@ -1,7 +1,7 @@
-import * as React from 'react'
-import {AppLayoutContext} from '../AppLayout'
+import { AppLayoutContext } from '../AppLayout'
+import React from 'react'
 
-export function useBreadcrumb(breadcrumb: React.ReactElement) {
+export function useBreadcrumb (breadcrumb: React.ReactElement) {
   const context = React.useContext(AppLayoutContext)
 
   React.useEffect(() => {

--- a/src/components/util/useDocumentTitle.ts
+++ b/src/components/util/useDocumentTitle.ts
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
 // a custom hook for setting the page title
-export function useDocumentTitle(title: string) {
+export function useDocumentTitle (title: string) {
   React.useEffect(() => {
     const originalTitle = document.title
     document.title = title

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,10 @@
+import App from './App'
+import { LastLocationProvider } from 'react-router-last-location'
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { BrowserRouter as Router } from 'react-router-dom'
-import { LastLocationProvider } from 'react-router-last-location'
-import './index.css'
-import App from './App'
 import * as serviceWorker from './serviceWorker'
+import './index.css'
 
 ReactDOM.render(
   <Router>

--- a/src/pages/Applications.tsx
+++ b/src/pages/Applications.tsx
@@ -3,11 +3,11 @@ import { useDocumentTitle } from '../components'
 import {
   PageSection,
   PageSectionVariants,
-  TextContent,
   Text,
-  TextVariants,
+  TextContent,
+  TextVariants
 } from '@patternfly/react-core'
-import { Table, TableHeader, TableBody } from '@patternfly/react-table'
+import { Table, TableBody, TableHeader } from '@patternfly/react-table'
 
 const Applications: React.FunctionComponent = () => {
   useDocumentTitle('Applications')
@@ -19,7 +19,7 @@ const Applications: React.FunctionComponent = () => {
     'Plan',
     'Created at'
   ]
-  let rows = [
+  const rows = [
     {
       cells: [
         'Application 1',
@@ -63,10 +63,10 @@ const Applications: React.FunctionComponent = () => {
       </PageSection>
 
       <PageSection>
-          <Table aria-label="Applications list" cells={columns} rows={rows}>
-            <TableHeader />
-            <TableBody />
-          </Table>     
+        <Table aria-label="Applications list" cells={columns} rows={rows}>
+          <TableHeader />
+          <TableBody />
+        </Table>
       </PageSection>
     </>
   )

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -1,22 +1,22 @@
 import React from 'react'
-import {useA11yRouteChange, useDocumentTitle} from '../components'
 import {
-  PageSection,
-  TextContent,
-  Title,
-  Text,
   Card,
-  CardBody
+  CardBody,
+  PageSection,
+  Text,
+  TextContent,
+  Title
 } from '@patternfly/react-core'
+import { useA11yRouteChange, useDocumentTitle } from '../components'
 
-const Overview: React.FunctionComponent = ({children}) => {
+const Overview: React.FunctionComponent = () => {
   useA11yRouteChange()
   useDocumentTitle('Overview')
   return (
     <>
-      <PageSection variant={'light'}>
+      <PageSection variant="light">
         <TextContent>
-          <Title size={'3xl'}>Overview</Title>
+          <Title size="3xl">Overview</Title>
           <Text>
             <b>Porta-fly</b> is a project to develop a new 3scale front end Patternfly-React app
           </Text>
@@ -26,10 +26,10 @@ const Overview: React.FunctionComponent = ({children}) => {
         <Card>
           <CardBody>
             <TextContent>
-            <Title size={'3xl'}>Porta-fly</Title>
-          <Text>
+              <Title size="3xl">Porta-fly</Title>
+              <Text>
             The 3scale Porta component is part of the 3Scale API Management solution...
-          </Text>
+              </Text>
             </TextContent>
           </CardBody>
         </Card>

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -18,33 +18,33 @@ const isLocalhost = Boolean(
     window.location.hostname.match(
       /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
     )
-);
+)
 
 type Config = {
   onSuccess?: (registration: ServiceWorkerRegistration) => void;
   onUpdate?: (registration: ServiceWorkerRegistration) => void;
 };
 
-export function register(config?: Config) {
+export function register (config?: Config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(
       (process as { env: { [key: string]: string } }).env.PUBLIC_URL,
       window.location.href
-    );
+    )
     if (publicUrl.origin !== window.location.origin) {
       // Our service worker won't work if PUBLIC_URL is on a different origin
       // from what our page is served on. This might happen if a CDN is used to
       // serve assets; see https://github.com/facebook/create-react-app/issues/2374
-      return;
+      return
     }
 
     window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`
 
       if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl, config);
+        checkValidServiceWorker(swUrl, config)
 
         // Add some additional logging to localhost, pointing developers to the
         // service worker/PWA documentation.
@@ -52,24 +52,24 @@ export function register(config?: Config) {
           console.log(
             'This web app is being served cache-first by a service ' +
               'worker. To learn more, visit https://bit.ly/CRA-PWA'
-          );
-        });
+          )
+        })
       } else {
         // Is not localhost. Just register service worker
-        registerValidSW(swUrl, config);
+        registerValidSW(swUrl, config)
       }
-    });
+    })
   }
 }
 
-function registerValidSW(swUrl: string, config?: Config) {
+function registerValidSW (swUrl: string, config?: Config) {
   navigator.serviceWorker
     .register(swUrl)
     .then(registration => {
       registration.onupdatefound = () => {
-        const installingWorker = registration.installing;
+        const installingWorker = registration.installing
         if (installingWorker == null) {
-          return;
+          return
         }
         installingWorker.onstatechange = () => {
           if (installingWorker.state === 'installed') {
@@ -79,39 +79,41 @@ function registerValidSW(swUrl: string, config?: Config) {
               // content until all client tabs are closed.
               console.log(
                 'New content is available and will be used when all ' +
-                  'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
-              );
+                'tabs for this page are closed. See https://bit.ly/CRA-PWA.'
+              )
 
               // Execute callback
               if (config && config.onUpdate) {
-                config.onUpdate(registration);
+                config.onUpdate(registration)
               }
             } else {
               // At this point, everything has been precached.
               // It's the perfect time to display a
               // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+              console.log('Content is cached for offline use.')
 
               // Execute callback
               if (config && config.onSuccess) {
-                config.onSuccess(registration);
+                config.onSuccess(registration)
               }
             }
           }
-        };
-      };
+        }
+      }
     })
     .catch(error => {
-      console.error('Error during service worker registration:', error);
-    });
+      console.error('Error during service worker registration:', error)
+    })
 }
 
-function checkValidServiceWorker(swUrl: string, config?: Config) {
+function checkValidServiceWorker (swUrl: string, config?: Config) {
   // Check if the service worker can be found. If it can't reload the page.
+  // FIXME: wrap fetch inside helper class
+  // eslint-disable-next-line no-undef
   fetch(swUrl)
     .then(response => {
       // Ensure service worker exists, and that we really are getting a JS file.
-      const contentType = response.headers.get('content-type');
+      const contentType = response.headers.get('content-type')
       if (
         response.status === 404 ||
         (contentType != null && contentType.indexOf('javascript') === -1)
@@ -119,25 +121,25 @@ function checkValidServiceWorker(swUrl: string, config?: Config) {
         // No service worker found. Probably a different app. Reload the page.
         navigator.serviceWorker.ready.then(registration => {
           registration.unregister().then(() => {
-            window.location.reload();
-          });
-        });
+            window.location.reload()
+          })
+        })
       } else {
         // Service worker found. Proceed as normal.
-        registerValidSW(swUrl, config);
+        registerValidSW(swUrl, config)
       }
     })
     .catch(() => {
       console.log(
         'No internet connection found. App is running in offline mode.'
-      );
-    });
+      )
+    })
 }
 
-export function unregister() {
+export function unregister () {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.ready.then(registration => {
-      registration.unregister();
-    });
+      registration.unregister()
+    })
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1561,6 +1561,17 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@typescript-eslint/eslint-plugin@^2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.15.0.tgz#5442c30b687ffd576ff74cfea46a6d7bfb0ee893"
+  integrity sha512-XRJFznI5v4K1WvIrWmjFjBAdQWaUTz4xJEdqR7+wAFsv6Q9dP3mOlE6BMNT3pdlp9eF1+bC5m5LZTmLMqffCVw==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "2.15.0"
+    eslint-utils "^1.4.3"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/eslint-plugin@^2.2.0":
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.12.0.tgz#0da7cbca7b24f4c6919e9eb31c704bfb126f90ad"
@@ -1581,6 +1592,25 @@
     "@typescript-eslint/typescript-estree" "2.12.0"
     eslint-scope "^5.0.0"
 
+"@typescript-eslint/experimental-utils@2.15.0", "@typescript-eslint/experimental-utils@^2.5.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.15.0.tgz#41e35313bfaef91650ddb5380846d1c78a780070"
+  integrity sha512-Qkxu5zndY5hqlcQkmA88gfLvqQulMpX/TN91XC7OuXsRf4XG5xLGie0sbpX97o/oeccjeZYRMipIsjKk/tjDHA==
+  dependencies:
+    "@types/json-schema" "^7.0.3"
+    "@typescript-eslint/typescript-estree" "2.15.0"
+    eslint-scope "^5.0.0"
+
+"@typescript-eslint/parser@^2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.15.0.tgz#379a71a51b0429bc3bc55c5f8aab831bf607e411"
+  integrity sha512-6iSgQsqAYTaHw59t0tdjzZJluRAjswdGltzKEdLtcJOxR2UVTPHYvZRqkAVGCkaMVb6Fpa60NnuozNCvsSpA9g==
+  dependencies:
+    "@types/eslint-visitor-keys" "^1.0.0"
+    "@typescript-eslint/experimental-utils" "2.15.0"
+    "@typescript-eslint/typescript-estree" "2.15.0"
+    eslint-visitor-keys "^1.1.0"
+
 "@typescript-eslint/parser@^2.2.0":
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.12.0.tgz#393f1604943a4ca570bb1a45bc8834e9b9158884"
@@ -1595,6 +1625,19 @@
   version "2.12.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.12.0.tgz#bd9e547ccffd17dfab0c3ab0947c80c8e2eb914c"
   integrity sha512-rGehVfjHEn8Frh9UW02ZZIfJs6SIIxIu/K1bbci8rFfDE/1lQ8krIJy5OXOV3DVnNdDPtoiPOdEANkLMrwXbiQ==
+  dependencies:
+    debug "^4.1.1"
+    eslint-visitor-keys "^1.1.0"
+    glob "^7.1.6"
+    is-glob "^4.0.1"
+    lodash.unescape "4.0.1"
+    semver "^6.3.0"
+    tsutils "^3.17.1"
+
+"@typescript-eslint/typescript-estree@2.15.0":
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.15.0.tgz#79ae52eed8701b164d91e968a65d85a9105e76d3"
+  integrity sha512-L6Pog+w3VZzXkAdyqA0VlwybF8WcwZX+mufso86CMxSdWmcizJ38lgBdpqTbc9bo92iyi0rOvmATKiwl+amjxg==
   dependencies:
     debug "^4.1.1"
     eslint-visitor-keys "^1.1.0"
@@ -2044,6 +2087,14 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+array.prototype.flat@^1.2.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
+  integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -4440,6 +4491,23 @@ eslint-config-react-app@^5.0.2:
   dependencies:
     confusing-browser-globals "^1.0.9"
 
+eslint-config-standard-jsx@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz#314c62a0e6f51f75547f89aade059bec140edfc7"
+  integrity sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==
+
+eslint-config-standard-react@^9.2.0:
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-react/-/eslint-config-standard-react-9.2.0.tgz#b21f05c087c1b0cfeea9fa3bff3cf42bd08a68a9"
+  integrity sha512-u+KRP2uCtthZ/W4DlLWCC59GZNV/y9k9yicWWammgTs/Omh8ZUUPF3EnYm81MAcbkYQq2Wg0oxutAhi/FQ8mIw==
+  dependencies:
+    eslint-config-standard-jsx "^8.0.0"
+
+eslint-config-standard@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz#b23da2b76fe5a2eba668374f246454e7058f15d4"
+  integrity sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==
+
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
@@ -4459,13 +4527,26 @@ eslint-loader@3.0.2:
     object-hash "^1.3.1"
     schema-utils "^2.2.0"
 
-eslint-module-utils@^2.4.0:
+eslint-module-utils@^2.4.0, eslint-module-utils@^2.4.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz#cdf0b40d623032274ccd2abd7e64c4e524d6e19c"
   integrity sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==
   dependencies:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
+
+eslint-plugin-es@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz#98cb1bc8ab0aa807977855e11ad9d1c9422d014b"
+  integrity sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
+eslint-plugin-eslint-plugin@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-plugin/-/eslint-plugin-eslint-plugin-2.2.0.tgz#6cac90a8085f658e892b155dda130deac54cfa51"
+  integrity sha512-X5+NT9a2GuwWyb3sHJdEEe6aD/30Fhi3/9XCmYHe/OSnWKUhmKOxFTfFM1AXZfJXjAoX7811bnoLI3fZr5AX5Q==
 
 eslint-plugin-flowtype@3.13.0:
   version "3.13.0"
@@ -4491,6 +4572,31 @@ eslint-plugin-import@2.18.2:
     read-pkg-up "^2.0.0"
     resolve "^1.11.0"
 
+eslint-plugin-import@^2.19.1:
+  version "2.19.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz#5654e10b7839d064dd0d46cd1b88ec2133a11448"
+  integrity sha512-x68131aKoCZlCae7rDXKSAQmbT5DQuManyXo2sK6fJJ0aK5CWAkv6A6HJZGgqC8IhjQxYPgo6/IY4Oz8AFsbBw==
+  dependencies:
+    array-includes "^3.0.3"
+    array.prototype.flat "^1.2.1"
+    contains-path "^0.1.0"
+    debug "^2.6.9"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.2"
+    eslint-module-utils "^2.4.1"
+    has "^1.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.0"
+    read-pkg-up "^2.0.0"
+    resolve "^1.12.0"
+
+eslint-plugin-jest@^23.3.0:
+  version "23.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.3.0.tgz#b1443d0c46d6a0de9ef3de78176dd6688c7d5326"
+  integrity sha512-GE6CR4ESJeu6Huw7vfZfaXHmX2R2kCFvf2X9OMcOxfP158yLKgLWz7PqLYTwRDACi84IhpmRxO8lK7GGwG05UQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "^2.5.0"
+
 eslint-plugin-jsx-a11y@6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz#b872a09d5de51af70a97db1eea7dc933043708aa"
@@ -4505,6 +4611,23 @@ eslint-plugin-jsx-a11y@6.2.3:
     emoji-regex "^7.0.2"
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
+
+eslint-plugin-node@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.0.0.tgz#365944bb0804c5d1d501182a9bc41a0ffefed726"
+  integrity sha512-chUs/NVID+sknFiJzxoN9lM7uKSOEta8GC8365hw1nDfwIPIjjpRSwwPvQanWv8dt/pDe9EV4anmVSwdiSndNg==
+  dependencies:
+    eslint-plugin-es "^3.0.0"
+    eslint-utils "^2.0.0"
+    ignore "^5.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.10.1"
+    semver "^6.1.0"
+
+eslint-plugin-promise@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"
+  integrity sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
 
 eslint-plugin-react-hooks@^1.6.1:
   version "1.7.0"
@@ -4525,6 +4648,27 @@ eslint-plugin-react@7.14.3:
     object.values "^1.1.0"
     prop-types "^15.7.2"
     resolve "^1.10.1"
+
+eslint-plugin-react@^7.17.0:
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.17.0.tgz#a31b3e134b76046abe3cd278e7482bd35a1d12d7"
+  integrity sha512-ODB7yg6lxhBVMeiH1c7E95FLD4E/TwmFjltiU+ethv7KPdCwgiFuOZg9zNRHyufStTDLl/dEFqI2Q1VPmCd78A==
+  dependencies:
+    array-includes "^3.0.3"
+    doctrine "^2.1.0"
+    eslint-plugin-eslint-plugin "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.2.3"
+    object.entries "^1.1.0"
+    object.fromentries "^2.0.1"
+    object.values "^1.1.0"
+    prop-types "^15.7.2"
+    resolve "^1.13.1"
+
+eslint-plugin-standard@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz#ff0519f7ffaff114f76d1bd7c3996eef0f6e20b4"
+  integrity sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -4549,6 +4693,13 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
+eslint-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
+  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
 eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
@@ -4558,6 +4709,49 @@ eslint@^6.1.0:
   version "6.7.2"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.7.2.tgz#c17707ca4ad7b2d8af986a33feba71e18a9fecd1"
   integrity sha512-qMlSWJaCSxDFr8fBPvJM9kJwbazrhNcBU3+DszDW1OlEwKBBRWsJc7NJFelvwQpanHCR14cOLD41x8Eqvo3Nng==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.10.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^1.4.3"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.2"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^7.0.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.14"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.3"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^6.1.2"
+    strip-ansi "^5.2.0"
+    strip-json-comments "^3.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+eslint@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
+  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"
@@ -5713,6 +5907,11 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+ignore@^5.1.1:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
+
 immer@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
@@ -6822,7 +7021,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-jsx-ast-utils@^2.1.0, jsx-ast-utils@^2.2.1:
+jsx-ast-utils@^2.1.0, jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.2.3.tgz#8a9364e402448a3ce7f14d357738310d9248054f"
   integrity sha512-EdIHFMm+1BPynpKOpdPqiOsvnIrInRGJD7bzPZdPkjitQEqpdpUuFpq4T0npZFKTiB3RhWFdGN+oqOJIdhDhQA==
@@ -7653,7 +7852,7 @@ object.entries@^1.1.0:
     function-bind "^1.1.1"
     has "^1.0.3"
 
-object.fromentries@^2.0.0:
+object.fromentries@^2.0.0, object.fromentries@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.2.tgz#4a09c9b9bb3843dd0f89acdb517a794d4f355ac9"
   integrity sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==
@@ -9558,6 +9757,13 @@ resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.3
   dependencies:
     path-parse "^1.0.6"
 
+resolve@^1.13.1:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.2.tgz#dbf31d0fa98b1f29aa5169783b9c290cb865fea2"
+  integrity sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==
+  dependencies:
+    path-parse "^1.0.6"
+
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
@@ -9752,7 +9958,7 @@ selfsigned@^1.9.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@6.3.0, semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
+semver@6.3.0, semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
Added `eslint` support for typescript and React. To run it use:
```bash
$ yarn lint [--fix]
```

The rules extend from the `standardjs` (to maintain coherence with [porta](https://github.com/3scale/porta)) project and I added others that are also considered good practice.

In order to make the most of the linter, consider installing a plugin in your IDE. Enabling _format on save` can also save up some time.

**TODO**:
- [ ] Create a hook to check format before committing/pushing?

**Configure VSCode**:
- Install extension: [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
- Add the following file `.vscode/settings.json`:
  ```
  {
    "editor.codeActionsOnSave": {
      "source.fixAll.eslint": true
    }
  }
  ```
- Make sure Eslint: Enable is checked in the settings.

**Configure Atom**:
- Install extension [linter-eslint](https://atom.io/packages/linter-eslint):
  `$ apm install linter-eslint`